### PR TITLE
feat: 도시 상세 페이지 구현

### DIFF
--- a/src/app/cities/[id]/loading.tsx
+++ b/src/app/cities/[id]/loading.tsx
@@ -1,0 +1,55 @@
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">
+      <div className="container mx-auto max-w-4xl px-4 py-8">
+        {/* 뒤로가기 버튼 스켈레톤 */}
+        <div className="h-6 w-32 bg-muted rounded animate-pulse mb-6" />
+
+        {/* 헤더 스켈레톤 */}
+        <div className="mb-8">
+          <div className="flex items-start justify-between gap-4 mb-4">
+            <div className="flex items-center gap-4">
+              <div className="h-16 w-16 bg-muted rounded-full animate-pulse" />
+              <div>
+                <div className="h-10 w-48 bg-muted rounded animate-pulse mb-2" />
+                <div className="h-6 w-24 bg-muted rounded animate-pulse" />
+              </div>
+            </div>
+            <div className="flex gap-3">
+              <div className="h-16 w-16 bg-muted rounded-lg animate-pulse" />
+              <div className="h-16 w-16 bg-muted rounded-lg animate-pulse" />
+            </div>
+          </div>
+
+          {/* 태그 스켈레톤 */}
+          <div className="flex flex-wrap gap-2 mb-6">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="h-6 w-20 bg-muted rounded animate-pulse" />
+            ))}
+          </div>
+        </div>
+
+        {/* 통계 카드 스켈레톤 */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="bg-card border rounded-xl p-6 shadow-sm">
+              <div className="h-5 w-32 bg-muted rounded animate-pulse mb-3" />
+              <div className="h-8 w-40 bg-muted rounded animate-pulse mb-2" />
+              <div className="h-4 w-24 bg-muted rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+
+        {/* 상세 정보 카드 스켈레톤 */}
+        <div className="bg-card border rounded-xl p-6 shadow-sm">
+          <div className="h-6 w-32 bg-muted rounded animate-pulse mb-4" />
+          <div className="space-y-4">
+            <div className="h-20 bg-muted rounded animate-pulse" />
+            <div className="h-20 bg-muted rounded animate-pulse" />
+            <div className="h-20 bg-muted rounded animate-pulse" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/cities/[id]/not-found.tsx
+++ b/src/app/cities/[id]/not-found.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link'
+import { Home, Search } from 'lucide-react'
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-background to-muted/20 flex items-center justify-center px-4">
+      <div className="text-center max-w-md">
+        <div className="mb-8">
+          <span className="text-8xl">🗺️</span>
+        </div>
+
+        <h1 className="text-4xl font-bold mb-4">도시를 찾을 수 없습니다</h1>
+
+        <p className="text-muted-foreground mb-8">
+          요청하신 도시 정보를 찾을 수 없습니다.<br />
+          도시 목록에서 다른 도시를 찾아보세요.
+        </p>
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-[var(--color-nomad-600)] text-white rounded-lg hover:bg-[var(--color-nomad-700)] transition-colors font-medium"
+          >
+            <Home className="h-4 w-4" />
+            홈으로 돌아가기
+          </Link>
+
+          <Link
+            href="/#cities"
+            className="inline-flex items-center justify-center gap-2 px-6 py-3 border border-input bg-background hover:bg-accent hover:text-accent-foreground rounded-lg transition-colors font-medium"
+          >
+            <Search className="h-4 w-4" />
+            도시 목록 보기
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/cities/[id]/page.tsx
+++ b/src/app/cities/[id]/page.tsx
@@ -1,0 +1,196 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft, ThumbsUp, ThumbsDown, Wifi, Wallet, Building2, Train } from 'lucide-react'
+import { CITIES } from '@/data/cities'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import type { Metadata } from 'next'
+
+interface Props {
+  params: Promise<{ id: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params
+  const city = CITIES.find((c) => c.id === id)
+
+  if (!city) {
+    return {
+      title: '도시를 찾을 수 없습니다 - Nomad Korea'
+    }
+  }
+
+  return {
+    title: `${city.name} - Nomad Korea`,
+    description: `${city.name} 워케이션 상세 정보 - ${city.tags.join(', ')}. ${city.region} 지역의 디지털 노마드를 위한 완벽한 장소.`,
+  }
+}
+
+export default async function CityDetailPage({ params }: Props) {
+  const { id } = await params
+  const city = CITIES.find((c) => c.id === id)
+
+  if (!city) {
+    notFound()
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">
+      <div className="container mx-auto max-w-4xl px-4 py-8">
+        {/* 뒤로가기 버튼 */}
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          목록으로 돌아가기
+        </Link>
+
+        {/* 헤더 섹션 */}
+        <div className="mb-8">
+          <div className="flex items-start justify-between gap-4 mb-4">
+            <div className="flex items-center gap-4">
+              <span className="text-6xl">{city.emoji}</span>
+              <div>
+                <h1 className="text-4xl font-bold mb-2">{city.name}</h1>
+                <p className="text-lg text-muted-foreground">{city.region}</p>
+              </div>
+            </div>
+
+            {/* 좋아요/싫어요 통계 */}
+            <div className="flex gap-3">
+              <div className="flex flex-col items-center gap-1 px-4 py-2 bg-green-50 dark:bg-green-950/20 rounded-lg border border-green-200 dark:border-green-800">
+                <ThumbsUp className="h-5 w-5 text-green-600 dark:text-green-400" />
+                <span className="text-sm font-semibold text-green-600 dark:text-green-400">
+                  {city.likes}
+                </span>
+              </div>
+              <div className="flex flex-col items-center gap-1 px-4 py-2 bg-red-50 dark:bg-red-950/20 rounded-lg border border-red-200 dark:border-red-800">
+                <ThumbsDown className="h-5 w-5 text-red-600 dark:text-red-400" />
+                <span className="text-sm font-semibold text-red-600 dark:text-red-400">
+                  {city.dislikes}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* 태그 */}
+          <div className="flex flex-wrap gap-2 mb-6">
+            {city.tags.map((tag) => (
+              <Badge key={tag} variant="secondary" className="text-sm">
+                #{tag}
+              </Badge>
+            ))}
+          </div>
+        </div>
+
+        {/* 주요 통계 정보 */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Wifi className="h-5 w-5 text-[var(--color-nomad-600)]" />
+                인터넷 속도
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-3xl font-bold">{city.internetSpeed} Mbps</p>
+              <p className="text-sm text-muted-foreground mt-1">
+                {city.internetSpeed >= 800 ? '초고속' : city.internetSpeed >= 500 ? '고속' : '표준'}
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Wallet className="h-5 w-5 text-[var(--color-nomad-600)]" />
+                월 생활비
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-3xl font-bold">
+                {city.monthlyCost.min}~{city.monthlyCost.max}만원
+              </p>
+              <p className="text-sm text-muted-foreground mt-1">
+                예산 레벨: {city.budgetLevel}
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Building2 className="h-5 w-5 text-[var(--color-nomad-600)]" />
+                코워킹 스페이스
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-3xl font-bold">{city.coworkingCount}개</p>
+              <p className="text-sm text-muted-foreground mt-1">
+                {city.coworkingCount >= 20 ? '매우 많음' : city.coworkingCount >= 10 ? '많음' : '보통'}
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Train className="h-5 w-5 text-[var(--color-nomad-600)]" />
+                서울 접근성
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-3xl font-bold">{city.seoulAccess}</p>
+              <p className="text-sm text-muted-foreground mt-1">
+                대중교통 이용 시
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* 추가 정보 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>상세 정보</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <h3 className="font-semibold mb-2">환경 타입</h3>
+              <Badge variant="outline" className="text-sm">
+                {city.environment === 'nature' && '🌳 자연'}
+                {city.environment === 'urban' && '🏙️ 도심'}
+                {city.environment === 'cafe' && '☕ 카페'}
+                {city.environment === 'coworking' && '💼 코워킹'}
+              </Badge>
+            </div>
+
+            <div>
+              <h3 className="font-semibold mb-2">최적 시즌</h3>
+              <div className="flex flex-wrap gap-2">
+                {city.bestSeasons.map((season) => (
+                  <Badge key={season} variant="secondary">
+                    {season === 'spring' && '🌸 봄'}
+                    {season === 'summer' && '☀️ 여름'}
+                    {season === 'autumn' && '🍂 가을'}
+                    {season === 'winter' && '❄️ 겨울'}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <h3 className="font-semibold mb-2">예산 정보</h3>
+              <p className="text-muted-foreground">
+                월 평균 생활비 기준: <span className="font-semibold text-foreground">{city.budgetLevel}</span>
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* 하단 여백 */}
+        <div className="h-8" />
+      </div>
+    </div>
+  )
+}

--- a/src/components/sections/seasonal/SeasonCityCard.tsx
+++ b/src/components/sections/seasonal/SeasonCityCard.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { SeasonalCity } from '@/data/seasonal'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -8,7 +9,8 @@ interface Props {
 
 export default function SeasonCityCard({ city }: Props) {
   return (
-    <Card className="hover:shadow-md transition-shadow">
+    <Link href={`/cities/${city.id}`} className="block">
+      <Card className="hover:shadow-md transition-shadow cursor-pointer">
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -37,5 +39,6 @@ export default function SeasonCityCard({ city }: Props) {
         </div>
       </CardContent>
     </Card>
+    </Link>
   )
 }

--- a/src/components/sections/top-cities/CityRankCard.tsx
+++ b/src/components/sections/top-cities/CityRankCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { ThumbsUp, ThumbsDown } from 'lucide-react'
 import { CityRank } from '@/types/city'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
@@ -23,7 +24,10 @@ export default function CityRankCard({ cityRank }: Props) {
                   rank === 2 ? 'border-gray-400 bg-gray-50 dark:bg-gray-950/20' :
                                'border-orange-400 bg-orange-50 dark:bg-orange-950/20'
 
-  const handleLike = () => {
+  const handleLike = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+
     if (liked) {
       // 이미 좋아요 상태면 취소
       setLiked(false)
@@ -40,7 +44,10 @@ export default function CityRankCard({ cityRank }: Props) {
     }
   }
 
-  const handleDislike = () => {
+  const handleDislike = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+
     if (disliked) {
       // 이미 싫어요 상태면 취소
       setDisliked(false)
@@ -58,7 +65,8 @@ export default function CityRankCard({ cityRank }: Props) {
   }
 
   return (
-    <Card className={`border-2 ${rankBg} hover:shadow-lg transition-shadow`}>
+    <Link href={`/cities/${city.id}`} className="block">
+      <Card className={`border-2 ${rankBg} hover:shadow-lg transition-shadow cursor-pointer`}>
       <CardHeader className="pb-3">
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-3">
@@ -131,5 +139,6 @@ export default function CityRankCard({ cityRank }: Props) {
         </div>
       </CardContent>
     </Card>
+    </Link>
   )
 }


### PR DESCRIPTION
## 📋 개요
도시 카드 클릭 시 해당 도시의 상세 정보를 보여주는 페이지를 구현했습니다.

## 🎯 구현 내용

### 1. 동적 라우팅 구현
- ✅ `/cities/[id]` 패턴으로 도시별 페이지 생성
- ✅ Next.js 16 App Router 사용
- ✅ 6개 도시 모두 접근 가능 (jeju, busan, gangneung, jeonju, chuncheon, gwangju)

### 2. 상세 페이지 UI
- ✅ 도시 헤더 (이모지, 이름, 지역)
- ✅ 좋아요/싫어요 통계 표시
- ✅ 주요 통계 정보 (인터넷 속도, 월 생활비, 코워킹, 서울 접근성)
- ✅ 추가 정보 (환경 타입, 최적 시즌, 예산 레벨, 태그)
- ✅ 뒤로가기 버튼

### 3. 카드 네비게이션
- ✅ CityRankCard에 Link 추가 (TOP 3 도시)
- ✅ SeasonCityCard에 Link 추가 (계절별 추천)
- ✅ 좋아요/싫어요 버튼과 카드 클릭 이벤트 충돌 방지 (`e.stopPropagation()`)

### 4. SEO 최적화
- ✅ `generateMetadata` 함수로 동적 메타데이터
- ✅ 도시별 title: `{도시명} - Nomad Korea`
- ✅ description에 도시 태그 및 정보 포함

### 5. UX 개선
- ✅ 404 페이지 (잘못된 도시 ID 접근 시)
- ✅ 로딩 스켈레톤 UI (loading.tsx)
- ✅ 반응형 디자인 (모바일/태블릿/데스크톱)

## 📂 변경된 파일

**신규 파일**:
- `src/app/cities/[id]/page.tsx` - 도시 상세 페이지
- `src/app/cities/[id]/loading.tsx` - 로딩 UI
- `src/app/cities/[id]/not-found.tsx` - 404 페이지

**수정 파일**:
- `src/components/sections/top-cities/CityRankCard.tsx` - Link 추가
- `src/components/sections/seasonal/SeasonCityCard.tsx` - Link 추가

## 🧪 테스트 방법

1. 메인 페이지에서 TOP 3 도시 카드 클릭
2. 도시 상세 페이지 확인:
   - http://localhost:3000/cities/jeju
   - http://localhost:3000/cities/busan
   - http://localhost:3000/cities/gangneung
3. 404 페이지 테스트: http://localhost:3000/cities/invalid
4. 좋아요/싫어요 버튼 클릭 시 페이지 이동하지 않는지 확인

## ✅ 완료 조건

- [x] 동적 라우팅 설정 완료
- [x] 도시 정보 상세 표시
- [x] 카드 클릭 시 상세 페이지로 이동
- [x] SEO 메타데이터 설정
- [x] 404 페이지 구현
- [x] 로딩 상태 처리
- [x] 반응형 디자인 적용
- [x] TypeScript 에러 없음
- [x] 프로덕션 빌드 성공

## 📸 주요 특징

- **Next.js 16 호환**: params를 Promise로 처리
- **이벤트 버블링 방지**: 좋아요/싫어요 버튼이 카드 클릭과 독립적으로 작동
- **타입 안정성**: City 타입 정확히 사용
- **스타일 일관성**: 기존 Card 컴포넌트 및 디자인 시스템 재사용

## 🔗 관련 이슈

Closes #2
Closes #3

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)