### PR TITLE
도시 카드 좋아요/싫어요 버튼 레이아웃 개선

### DIFF
--- a/src/app/cities/[id]/page.tsx
+++ b/src/app/cities/[id]/page.tsx
@@ -49,7 +49,16 @@ export default async function CityDetailPage({ params }: Props) {
         {/* 헤더 섹션 */}
         <div className="mb-8">
           <div className="flex items-start justify-between gap-4 mb-4">
-            <div className="flex items-center gap-4">
+            {/* 좋아요 통계 - 왼쪽 */}
+            <div className="flex items-center gap-1 px-4 py-2 bg-green-50 dark:bg-green-950/20 rounded-lg border border-green-200 dark:border-green-800">
+              <ThumbsUp className="h-5 w-5 text-green-600 dark:text-green-400" />
+              <span className="text-sm font-semibold text-green-600 dark:text-green-400">
+                {city.likes}
+              </span>
+            </div>
+
+            {/* 도시 정보 - 중앙 */}
+            <div className="flex items-center gap-4 flex-1">
               <span className="text-6xl">{city.emoji}</span>
               <div>
                 <h1 className="text-4xl font-bold mb-2">{city.name}</h1>
@@ -57,20 +66,12 @@ export default async function CityDetailPage({ params }: Props) {
               </div>
             </div>
 
-            {/* 좋아요/싫어요 통계 */}
-            <div className="flex gap-3">
-              <div className="flex flex-col items-center gap-1 px-4 py-2 bg-green-50 dark:bg-green-950/20 rounded-lg border border-green-200 dark:border-green-800">
-                <ThumbsUp className="h-5 w-5 text-green-600 dark:text-green-400" />
-                <span className="text-sm font-semibold text-green-600 dark:text-green-400">
-                  {city.likes}
-                </span>
-              </div>
-              <div className="flex flex-col items-center gap-1 px-4 py-2 bg-red-50 dark:bg-red-950/20 rounded-lg border border-red-200 dark:border-red-800">
-                <ThumbsDown className="h-5 w-5 text-red-600 dark:text-red-400" />
-                <span className="text-sm font-semibold text-red-600 dark:text-red-400">
-                  {city.dislikes}
-                </span>
-              </div>
+            {/* 싫어요 통계 - 오른쪽 */}
+            <div className="flex items-center gap-1 px-4 py-2 bg-red-50 dark:bg-red-950/20 rounded-lg border border-red-200 dark:border-red-800">
+              <span className="text-sm font-semibold text-red-600 dark:text-red-400">
+                {city.dislikes}
+              </span>
+              <ThumbsDown className="h-5 w-5 text-red-600 dark:text-red-400" />
             </div>
           </div>
 

--- a/src/components/sections/top-cities/CityRankCard.tsx
+++ b/src/components/sections/top-cities/CityRankCard.tsx
@@ -68,8 +68,22 @@ export default function CityRankCard({ cityRank }: Props) {
     <Link href={`/cities/${city.id}`} className="block">
       <Card className={`border-2 ${rankBg} hover:shadow-lg transition-shadow cursor-pointer`}>
       <CardHeader className="pb-3">
-        <div className="flex items-start justify-between">
-          <div className="flex items-center gap-3">
+        <div className="flex items-start justify-between gap-3">
+          {/* 좋아요 버튼 - 왼쪽 */}
+          <button
+            onClick={handleLike}
+            className="flex items-center gap-1 px-3 py-2 rounded-lg hover:bg-accent transition-colors"
+          >
+            <ThumbsUp
+              className={`h-5 w-5 ${liked ? 'fill-green-500 text-green-500' : 'text-gray-400'}`}
+            />
+            <span className={`text-sm font-semibold ${liked ? 'text-green-500' : 'text-muted-foreground'}`}>
+              {likesCount}
+            </span>
+          </button>
+
+          {/* 도시 정보 - 중앙 */}
+          <div className="flex items-center gap-3 flex-1">
             <span className="text-3xl">{rankBadge}</span>
             <div>
               <div className="flex items-center gap-2">
@@ -80,31 +94,18 @@ export default function CityRankCard({ cityRank }: Props) {
             </div>
           </div>
 
-          {/* 좋아요/싫어요 버튼 */}
-          <div className="flex gap-2">
-            <button
-              onClick={handleLike}
-              className="flex flex-col items-center gap-1 px-3 py-2 rounded-lg hover:bg-accent transition-colors"
-            >
-              <ThumbsUp
-                className={`h-5 w-5 ${liked ? 'fill-green-500 text-green-500' : 'text-gray-400'}`}
-              />
-              <span className={`text-sm font-semibold ${liked ? 'text-green-500' : 'text-muted-foreground'}`}>
-                {likesCount}
-              </span>
-            </button>
-            <button
-              onClick={handleDislike}
-              className="flex flex-col items-center gap-1 px-3 py-2 rounded-lg hover:bg-accent transition-colors"
-            >
-              <ThumbsDown
-                className={`h-5 w-5 ${disliked ? 'fill-red-500 text-red-500' : 'text-gray-400'}`}
-              />
-              <span className={`text-sm font-semibold ${disliked ? 'text-red-500' : 'text-muted-foreground'}`}>
-                {dislikesCount}
-              </span>
-            </button>
-          </div>
+          {/* 싫어요 버튼 - 오른쪽 */}
+          <button
+            onClick={handleDislike}
+            className="flex items-center gap-1 px-3 py-2 rounded-lg hover:bg-accent transition-colors"
+          >
+            <span className={`text-sm font-semibold ${disliked ? 'text-red-500' : 'text-muted-foreground'}`}>
+              {dislikesCount}
+            </span>
+            <ThumbsDown
+              className={`h-5 w-5 ${disliked ? 'fill-red-500 text-red-500' : 'text-gray-400'}`}
+            />
+          </button>
         </div>
       </CardHeader>
 


### PR DESCRIPTION
## Summary
이슈 #5를 해결하기 위한 도시 카드 UI 개선 작업입니다.

## 주요 변경사항
- ✅ 좋아요 버튼을 왼쪽으로, 싫어요 버튼을 오른쪽으로 양쪽 정렬
- ✅ 도시 정보를 중앙에 배치하여 시각적 균형 개선
- ✅ 버튼 레이아웃을 수직에서 수평으로 변경 ([아이콘 숫자] 형태)
- ✅ 리스트 카드와 상세 페이지에 일관된 레이아웃 적용

## Before & After

**이전 레이아웃**:
```
┌─────────────────────────────────────┐
│ [🥇] [🏝️ 제주시]    [👍] [👎]     │
│         제주도        245   18      │
└─────────────────────────────────────┘
```

**변경 후 레이아웃**:
```
┌─────────────────────────────────────┐
│ [👍 245]  [🥇] [🏝️ 제주시]  [18 👎]│
│                  제주도              │
└─────────────────────────────────────┘
```

## 변경된 파일
- `src/components/sections/top-cities/CityRankCard.tsx` - 도시 랭킹 카드 레이아웃
- `src/app/cities/[id]/page.tsx` - 도시 상세 페이지 레이아웃

## Test plan
- [x] TypeScript 에러 없음
- [x] 빌드 성공
- [x] 좋아요/싫어요 버튼 클릭 시 페이지 이동하지 않음
- [x] 버튼 상태 토글 정상 작동
- [x] hover 효과 및 색상 유지

## Resolves
Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)